### PR TITLE
Drop number of Rocket threads to 1

### DIFF
--- a/obmc-rest
+++ b/obmc-rest
@@ -589,5 +589,7 @@ if __name__ == '__main__':
 			443,
 			default_cert,
 			default_cert),
-		'wsgi', {'wsgi_app': app})
+		'wsgi', {'wsgi_app': app},
+		min_threads = 1,
+		max_threads = 1)
 	server.start()


### PR DESCRIPTION
By default Rocket creates a threadpool 8 deep which uses a fair
amount of memory.  We don't need a multi-threaded server so this
patch drops the min/max to 1.
