### PR TITLE
Add a convenient/short logout command

### DIFF
--- a/obmc-rest
+++ b/obmc-rest
@@ -411,6 +411,7 @@ class SessionHandler(MethodHandler):
     ''' Handles the /login and /logout routes, manages
     server side session store and session cookies.  '''
 
+    verbs = ['POST', 'GET']
     rules = ['/login', '/logout']
     login_str = "User '%s' logged %s"
     bad_passwd_str = "Invalid username or password"
@@ -459,6 +460,10 @@ class SessionHandler(MethodHandler):
         return self.get_session(
             request.get_cookie(
                 'sid', secret=self.hmac_key))
+
+    def do_get(self, **kw):
+        if request.path == '/logout':
+            return self.do_logout(**kw)
 
     def do_post(self, **kw):
         if request.path == '/login':


### PR DESCRIPTION
With this patch, we can logout by:
    curl -c cjar -b cjar -k https://BMC/logout
Traditional/json format logout is retained.

Signed-off-by: Nan Li bjlinan@cn.ibm.com

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openbmc/phosphor-rest-server/22)

<!-- Reviewable:end -->
